### PR TITLE
Discriminator Class without sklearn Dependency

### DIFF
--- a/qiskit_experiments/measurement/discriminator/__init__.py
+++ b/qiskit_experiments/measurement/discriminator/__init__.py
@@ -12,3 +12,4 @@
 # that they have been altered from the originals.
 
 from .discriminator_experiment import DiscriminatorExperiment, DiscriminatorAnalysis
+from .discriminator_nosklearn import LDAnosklearn, QDAnosklearn

--- a/qiskit_experiments/measurement/discriminator/discriminator_experiment.py
+++ b/qiskit_experiments/measurement/discriminator/discriminator_experiment.py
@@ -7,7 +7,6 @@ from qiskit_experiments.base_experiment import BaseExperiment
 from qiskit.circuit import QuantumCircuit
 from .discriminator_analysis import DiscriminatorAnalysis
 from typing import List, Optional, Union, Iterable
-from qiskit.qobj.utils import MeasLevel
 
 
 class DiscriminatorExperiment(BaseExperiment):
@@ -15,10 +14,6 @@ class DiscriminatorExperiment(BaseExperiment):
 
     # Analysis class for experiment
     __analysis_class__ = DiscriminatorAnalysis
-
-    # default run options
-    __run_defaults__ = {"meas_level": MeasLevel.KERNELED, "meas_return": "single"}
-
 
     def __init__(
         self,

--- a/qiskit_experiments/measurement/discriminator/discriminator_nosklearn.py
+++ b/qiskit_experiments/measurement/discriminator/discriminator_nosklearn.py
@@ -1,0 +1,90 @@
+import numpy as np
+from numpy.linalg import inv
+from math import log
+
+    
+
+class LDAnosklearn():
+    
+    def __init__(self):
+        return None
+    
+    def fit(self, X, y):
+        X0 = X[y==0]
+        X1 = X[y==1]
+        self.X0_mean = np.mean(X0,axis=0).reshape(1,2)
+        self.X1_mean = np.mean(X1,axis=0).reshape(1,2)
+        N_zeros = len(X0)
+        N_ones = len(X1)
+        K=2
+        sigma_X0 = np.dot((X0-self.X0_mean).T,(X0-self.X0_mean))/(N_zeros-K)
+        sigma_X1 = np.dot((X1-self.X1_mean).T,(X1-self.X1_mean))/(N_ones-K)
+        sigma = sigma_X0 + sigma_X1
+        self.sigma_inv = inv(sigma)
+        self.RHS = 0.5*np.matmul(np.matmul((self.X1_mean+self.X0_mean),self.sigma_inv),(self.X1_mean-self.X0_mean).T) - log(N_ones/N_zeros)
+        return self
+    
+    def predict(self, X):
+        LHS = np.matmul(np.matmul(X,self.sigma_inv),(self.X1_mean-self.X0_mean).T)
+        a = []
+        for i in range(len(LHS)):
+            if (LHS[i]>self.RHS):
+                a.append(1)
+            else: a.append(0)
+        a = np.array(a)
+        return a
+    
+    def score(self,X,y_true):
+        y_pred = self.predict(X)
+        count = 0
+        for i in range(len(y_true)):
+            if (y_true[i]==y_pred[i]):
+                count = count + 1
+        return count/len(y_true)
+
+            
+        
+
+
+class QDAnosklearn():
+    
+    def __init__(self):
+        return None
+    
+    def fit(self, X, y):
+        X0 = X[y==0]
+        X1 = X[y==1]
+        self.X0_mean = np.mean(X0,axis=0).reshape(1,2)
+        self.X1_mean = np.mean(X1,axis=0).reshape(1,2)
+        N_zeros = len(X0)
+        N_ones = len(X1)
+        K=2
+        self.sigma_X0 = np.dot((X0-self.X0_mean).T,(X0-self.X0_mean))/(N_zeros-K)
+        self.sigma_X1 = np.dot((X1-self.X1_mean).T,(X1-self.X1_mean))/(N_ones-K)
+        sigma = self.sigma_X0 + self.sigma_X1
+        self.sigma_inv = inv(sigma)
+        self.log_sigma_X0 = np.log(np.linalg.det(self.sigma_X0))
+        self.log_sigma_X1 = np.log(np.linalg.det(self.sigma_X1))
+        return self
+    
+    def predict(self, X):
+        a = []
+        for p in range(X.shape[0]):
+            delta_0 = -0.5*self.log_sigma_X0 - 0.5*np.matmul(np.matmul((X[p]-self.X0_mean),inv(self.sigma_X0)),(X[p]-self.X0_mean).T) + 0.5
+            delta_1 = -0.5*self.log_sigma_X1 - 0.5*np.matmul(np.matmul((X[p]-self.X1_mean),inv(self.sigma_X1)),(X[p]-self.X1_mean).T) + 0.5
+            if (delta_0>delta_1):
+                a.append(0)
+            else:
+                a.append(1)
+        return a
+    
+    def score(self,X,y_true):
+        y_pred = self.predict(X)
+        count = 0
+        for i in range(len(y_true)):
+            if (y_true[i]==y_pred[i]):
+                count = count + 1
+        return count/len(y_true)
+
+       
+

--- a/qiskit_experiments/measurement/discriminator/discriminator_nosklearn.py
+++ b/qiskit_experiments/measurement/discriminator/discriminator_nosklearn.py
@@ -1,3 +1,7 @@
+"""
+Linear and Quadratic Discriminant Analysis calculations without sklearn.
+"""
+
 import numpy as np
 from numpy.linalg import inv
 from math import log
@@ -5,11 +9,29 @@ from math import log
     
 
 class LDAnosklearn():
+    """Calculation of Linear Discriminant Analysis without sklearn."""
     
     def __init__(self):
         return None
     
     def fit(self, X, y):
+        """Calculation for Linear Discriminant Analysis (LDA) model according to the 
+        given training data and parameters without sklearn.
+        
+        The formula for the LDA classification has been taken from Eqn. 4.11 of the book,
+        Hastie, Trevor, et al. The Elements of Statistical Learning. 
+        Second Edition. Stanford, California. August 2008.
+     
+        Parameters
+        ----------
+        
+        X : array-like of shape (n_samples,n_features) where n_features=2 (0 and 1)
+            Training data.
+            
+        y : array-like of shape (n_samples,)
+            Target values.
+        
+        """
         X0 = X[y==0]
         X1 = X[y==1]
         self.X0_mean = np.mean(X0,axis=0).reshape(1,2)
@@ -25,6 +47,22 @@ class LDAnosklearn():
         return self
     
     def predict(self, X):
+        """Perform classification on an array of test vectors X.
+        
+        The predicted class C for each sample in X is returned.
+        
+        Parameters
+        ----------
+        
+        X : array-like of shape (n_samples, n_features) where n_features=2 (0 and 1)
+        
+        Returns
+        -------
+        
+        C : ndarray of shape (n_samples,)
+        
+        """
+        
         LHS = np.matmul(np.matmul(X,self.sigma_inv),(self.X1_mean-self.X0_mean).T)
         a = []
         for i in range(len(LHS)):
@@ -35,6 +73,22 @@ class LDAnosklearn():
         return a
     
     def score(self,X,y_true):
+        """Return the mean accuracy on the given test data and labels.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features) where n_features=2 (0 and 1)
+            Test samples.
+            
+        y : array-like of shape (n_samples,)
+            True labels for `X`.
+            
+        Returns
+        -------
+        score : float
+            Mean accuracy of ``self.predict(X)`` wrt. `y`.
+        
+        """
         y_pred = self.predict(X)
         count = 0
         for i in range(len(y_true)):
@@ -47,11 +101,30 @@ class LDAnosklearn():
 
 
 class QDAnosklearn():
+    """Calculation of Quadratic Discriminant Analysis without sklearn."""
     
     def __init__(self):
         return None
     
     def fit(self, X, y):
+        """Calculation for Quadratic Discriminant Analysis (QDA) model according to the 
+        given training data and parameters without sklearn.
+        
+        The formula for the QDA classification has been taken from Eqn. 4.12 of the book,
+        Hastie, Trevor, et al. The Elements of Statistical Learning. 
+        Second Edition. Stanford, California. August 2008.
+        
+        Parameters
+        ----------
+        
+        X : array-like of shape (n_samples,n_features) where n_features=2 (0 and 1)
+            Training data.
+            
+        y : array-like of shape (n_samples,)
+            Target values.
+        
+        """
+        
         X0 = X[y==0]
         X1 = X[y==1]
         self.X0_mean = np.mean(X0,axis=0).reshape(1,2)
@@ -68,6 +141,23 @@ class QDAnosklearn():
         return self
     
     def predict(self, X):
+        """Perform classification on an array of test vectors X.
+        
+        The predicted class C for each sample in X is returned.
+        
+        Parameters
+        ----------
+        
+        X : array-like of shape (n_samples, n_features) where n_features=2 (0 and 1)
+        
+        Returns
+        -------
+        
+        C : ndarray of shape (n_samples,)
+        
+        """
+        
+        
         a = []
         for p in range(X.shape[0]):
             delta_0 = -0.5*self.log_sigma_X0 - 0.5*np.matmul(np.matmul((X[p]-self.X0_mean),inv(self.sigma_X0)),(X[p]-self.X0_mean).T) + 0.5
@@ -79,6 +169,22 @@ class QDAnosklearn():
         return a
     
     def score(self,X,y_true):
+        """Return the mean accuracy on the given test data and labels.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features) where n_features=2 (0 and 1)
+            Test samples.
+            
+        y : array-like of shape (n_samples,)
+            True labels for `X`.
+            
+        Returns
+        -------
+        score : float
+            Mean accuracy of ``self.predict(X)`` wrt. `y`.
+        
+        """
         y_pred = self.predict(X)
         count = 0
         for i in range(len(y_true)):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The current Discriminator code uses LDA and QDA from sklearn library. There is a need to remove this dependency of the code on sklearn library. This PR adds the logic that performs the LDA and QDA without sklearn library.


### Details and comments
A new python module called discriminator_nosklearn is introduced that includes two classes: LDAnosklearn and QDAnosklearn. Using this module, there will be no dependency on the sklearn package while performing the discriminator.

